### PR TITLE
Fontapis and github star button to https

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
 
     <link rel="icon" type="image/png" href="/static/favicon.png"/>
 
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.min.css">
@@ -84,7 +84,7 @@
     <div id="communityFooter">
         Community&nbsp;<i class="fa fa-comment"></i>&nbsp;: &nbsp;<a target="_blank" href="https://zclassic.herokuapp.com">#zclassic IRC</a>
         &nbsp;&nbsp;|&nbsp;&nbsp;
-        <iframe src="http://ghbtns.com/github-btn.html?user=s-nomp&repo=s-nomp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="140" height="20"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=s-nomp&repo=s-nomp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="140" height="20"></iframe>
     </div>
 
 </footer>


### PR DESCRIPTION
Modified URLs to use https because browsers (google chrome) flags the website as insecure when requesting not secured content.